### PR TITLE
update jquery to ~1.10 in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "Wardrobe",
   "version": "0.1.0",
   "dependencies": {
-    "jquery": "1.9.1",
+    "jquery": "~1.10",
     "backbone": "latest",
     "underscore": "latest",
     "backbone.marionette": "latest",


### PR DESCRIPTION
Updating jquery to version ~1.10.
The ~ says it should be around 1.10.
Maybe 1.10.1 or the current 1.10.2 or in the future 1.10.3
