### PR TITLE
Switched to MarkdownExtra parser that supports classes on code blocks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=5.3.0",
         "laravel/framework": "4.0.x",
-        "dflydev/markdown": "1.0.*@dev",
+        "michelf/php-markdown": "1.3.*@dev",
         "symfony/yaml": "2.4.*@dev"
     },
     "autoload": {

--- a/src/themeHelpers.php
+++ b/src/themeHelpers.php
@@ -54,16 +54,13 @@ function theme_view($file = null)
 	return Config::get('core::wardrobe.theme').'.'.$file;
 }
 
-use dflydev\markdown\MarkdownExtraParser;
+use \Michelf\MarkdownExtra;
 
 if ( ! function_exists('md'))
 {
 	function md($str)
 	{
-		$markdownParser = new MarkdownExtraParser();
-
-		// Parse the loaded source.
-		return $markdownParser->transformMarkdown($str);
+		return MarkdownExtra::defaultTransform($str);
 	}
 }
 


### PR DESCRIPTION
Makes it easier to integrate syntax highlighting plugins like Prism.js that rely on class names in code blocks to recognize the language.
