### PR TITLE
Fixed crash with recursive directories.

### DIFF
--- a/src/Wardrobe/Core/Console/ThemeCommand.php
+++ b/src/Wardrobe/Core/Console/ThemeCommand.php
@@ -61,7 +61,7 @@ class ThemeCommand extends Command {
 	protected function checkDirectory($dir)
 	{
 		if (!File::isDirectory($dir)) {
-			File::makeDirectory($dir);
+			File::makeDirectory($dir, 0777, true);
 		}
 	}
 }


### PR DESCRIPTION
The `wardrobe:themes` command currently crashes because it's trying to create nested directories (e.g. `themes/default/css` when `themes/default` doesn't exist).
