### PR TITLE
Fixing un-namespaced URL call.

### DIFF
--- a/src/Wardrobe/Core/Facades/Wardrobe.php
+++ b/src/Wardrobe/Core/Facades/Wardrobe.php
@@ -60,7 +60,7 @@ class Wardrobe {
 		}
 		else
 		{
-			return URL::route('wardrobe.'.$route, $param);
+			return \URL::route('wardrobe.'.$route, $param);
 		}
 	}
 


### PR DESCRIPTION
If you're not using the default wardrobe route and using something like /blog, this will throw an exception saying Wardrobe\URL doesn't exist.
