### PR TITLE
Changing require to require_once in ServiceProvider

### DIFF
--- a/src/Wardrobe/Core/WardrobeServiceProvider.php
+++ b/src/Wardrobe/Core/WardrobeServiceProvider.php
@@ -24,9 +24,9 @@ class WardrobeServiceProvider extends ServiceProvider {
 		$this->bindRepositories();
 		$this->bootCommands();
 
-		require __DIR__.'/../../themeHelpers.php';
-		require __DIR__.'/../../routes.php';
-		require __DIR__.'/../../filters.php';
+		require_once __DIR__.'/../../themeHelpers.php';
+		require_once __DIR__.'/../../routes.php';
+		require_once __DIR__.'/../../filters.php';
 	}
 
 	/**


### PR DESCRIPTION
If these are just 'require', when you run any unit tests it will fail on a fatal error that the functions have been previously declared.
