### PR TITLE
Sorting by Status Fix / Typo Fix

### DIFF
--- a/assets/coffee/apps/post/list/list_view.coffee
+++ b/assets/coffee/apps/post/list/list_view.coffee
@@ -80,7 +80,7 @@
         @isMatch(post, sorter, filter)
 
     isMatch: (post, sorter, filter) ->
-      foundId = if sorter is "" or post.get("active") is sorter then post.id else null
+      foundId = if sorter is "" or post.get("active").toString() is sorter then post.id else null
       if foundId and filter isnt ""
         pattern = new RegExp(filter,"gi")
         foundId = pattern.test post.get("title")

--- a/assets/coffee/apps/post/post_app.coffee
+++ b/assets/coffee/apps/post/post_app.coffee
@@ -43,13 +43,13 @@
     App.navigate "post/edit/#{item.id}"
     API.edit item.id, item
 
-  # When the new post link is clicked the show the add routine.
+  # When the new post link is clicked then show the add routine.
   App.vent.on "post:new:clicked post:new", ->
     App.navigate "/",
       trigger: false
     API.add()
 
-  # When the edit post link is clicked the show the edit routine.
+  # When the edit post link is clicked then show the edit routine.
   App.vent.on "post:item:clicked", (item) ->
     App.navigate "post/edit/#{item.id}"
     API.edit item.id, item


### PR DESCRIPTION
line: post.get("active") is sorter
would check for: 1 === "1"

Safer to cast to string rather than casting to int. We could also use raw JS `post.get("active") == sorter`.
