### PR TITLE
Update DbPostRepository.php

### DIFF
--- a/src/Wardrobe/Core/Repositories/DbPostRepository.php
+++ b/src/Wardrobe/Core/Repositories/DbPostRepository.php
@@ -237,7 +237,7 @@ class DbPostRepository implements PostRepositoryInterface {
 	 */
 	public function allTags()
 	{
-		return Tag::orderBy('tag', 'asc')->groupBy('tag')->distinct()->get()->toArray();
+		return Tag::orderBy('tag', 'asc')->groupBy('tag')->distinct()->get(array('tag'))->toArray();
 	}
 
 	/**


### PR DESCRIPTION
PostgreSQL throws an error on pages calling the allTags. Reason is  post_id should also appear in the groupBy to make is valid SQL. Therefor I changed the query to do a 'select tag' rahter tehn a 'select *'
