### PR TITLE
fix double / in url

### DIFF
--- a/src/themeHelpers.php
+++ b/src/themeHelpers.php
@@ -70,7 +70,7 @@ function wardrobe_url($link)
     	$link = substr($link, 1);
 	}
 	if (route('wardrobe.index', null, false) !== '/') {
-		return route('wardrobe.index')."/{$link}";
+		return route('wardrobe.index')."{$link}";
 	} else {
 		return url($link);
 	}


### PR DESCRIPTION
This helper generate 404 error because of double / it url.
