### PR TITLE
DB Repository groupBy in search method: use posts.id

### DIFF
--- a/src/Wardrobe/Core/Repositories/DbPostRepository.php
+++ b/src/Wardrobe/Core/Repositories/DbPostRepository.php
@@ -103,7 +103,7 @@ class DbPostRepository implements PostRepositoryInterface {
 			->orderBy('posts.publish_date', 'desc')
 			->where('posts.active', '=', 1)
 			->where('posts.publish_date', '<=', new DateTime)
-			->groupBy('id')
+			->groupBy('posts.id')
 			->distinct()
 			->paginate($per_page);
 	}


### PR DESCRIPTION
in line 106 `groupBy('id')` cause an "Ambiguous column ERROR" in Postgresql, i found that change id to posts.id can fix it
