### PR TITLE
Adding slash to wardrobe_url

### DIFF
--- a/src/themeHelpers.php
+++ b/src/themeHelpers.php
@@ -70,7 +70,7 @@ function wardrobe_url($link)
     	$link = substr($link, 1);
 	}
 	if (route('wardrobe.index', null, false) !== '/') {
-		return route('wardrobe.index')."{$link}";
+		return route('wardrobe.index')."/{$link}";
 	} else {
 		return url($link);
 	}


### PR DESCRIPTION
This needs a slash before the links to work on 4.1.
