### PR TITLE
Added S3 as a storage option for image uploads

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "laravel/framework": "~4",
     "michelf/php-markdown": "1.3.*@dev",
     "symfony/yaml": "2.4.*@dev",
-    "intervention/image": "1.4.*"
+    "intervention/image": "1.4.*",
+    "aws/aws-sdk-php": "2.5.*"
   },
   "require-dev": {
     "mockery/mockery": "dev-master",

--- a/src/config/wardrobe.php
+++ b/src/config/wardrobe.php
@@ -15,6 +15,17 @@ return array(
 
     /*
     |--------------------------------------------------------------------------
+    | Image Storage
+    |--------------------------------------------------------------------------
+    |
+    | Set this to indicate how to store uploaded imates. Values are 'filesystem'
+    | or 's3'. If s3 is indicated, set your credentials below.
+    |
+    */
+    'image_storage' => 'filesystem',
+
+    /*
+    |--------------------------------------------------------------------------
     | Image Uploads Directory
     |--------------------------------------------------------------------------
     |
@@ -37,6 +48,20 @@ return array(
         'enabled'       => false,
         'width'         => '600',
         'height'        => '600',
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Image S3 Creds
+    |--------------------------------------------------------------------------
+    |
+    | If using S3 as the image storage, specify your S3 credentials here.
+    |
+    */
+    'image_s3_creds' => array(
+        'bucket'       => 'bucket',
+        'api_key'      => 'key',
+        'api_secret'   => 'secret',
     ),
 
     /*


### PR DESCRIPTION
I had to add this functionality so that I could deploy to Heroku. Heroku does not retain the "public" directory (or anything else for that matter) when you push an update, so storing elsewhere is required.
