### PR TITLE
Feature: File storage driver with local system and S3 support

### DIFF
--- a/src/Wardrobe/Core/Repositories/FileStorageRepository.php
+++ b/src/Wardrobe/Core/Repositories/FileStorageRepository.php
@@ -5,14 +5,41 @@ use Illuminate\Support\Contracts\MessageProviderInterface;
 
 class FileStorageRepository implements FileStorageRepositoryInterface {
 
+    /**
+     * The directory in which to store the files
+     *
+     * @var string
+     */
     protected $storageDirectory;
 
+    /**
+     * The full destination path of the file
+     *
+     * @var string
+     */
     protected $destinationPath;
 
+    /**
+     * The directory in which to store the files
+     *
+     * @var string
+     */
     protected $messsages;
 
+    /**
+     * The array of storage directories keyed by file type in the Wardrobe config
+     *
+     * @var array
+     */
     protected $storageDirectories;
 
+    /**
+     * Constructor
+     *
+     * @param  Illuminate\Support\Contracts\MessageProviderInterface  $messages
+     * 
+     * @return \Wardrobe\Core\Repositories\FileStorageRepositoryInterface
+     */
     public function __construct(MessageProviderInterface $messages)
     {
         $this->messages = $messages;
@@ -20,7 +47,7 @@ class FileStorageRepository implements FileStorageRepositoryInterface {
     }
 
     /**
-     * Saves file in chosen storge 
+     * Saves file in chosen storage 
      *
      * @param  string  $content
      * @param  string  $last_name
@@ -34,16 +61,24 @@ class FileStorageRepository implements FileStorageRepositoryInterface {
         return $this->messages->getMessageBag();
     }
 
+    /**
+     * Sets destination path based on file type
+     *
+     * @param  string  $type
+     * 
+     * @return void
+     */
     protected function setDestinationPath($type)
     {
         switch($type)
         {
             case "image":
                 $this->storageDirectory = $this->storageDirectories['image'];
+                if(!$this->storageDirectory || $this->storageDirectory == "") $this->storageDirectory = "images";
                 break;
             default:
                 $this->storageDirectory = $this->storageDirectories['default'];
-                if($dir == "") $this->storageDirectory = "files";
+                if(!$this->storageDirectory || $this->storageDirectory == "") $this->storageDirectory = "files";
                 break;
         }
 

--- a/src/Wardrobe/Core/Repositories/FileStorageRepository.php
+++ b/src/Wardrobe/Core/Repositories/FileStorageRepository.php
@@ -1,0 +1,52 @@
+<?php namespace Wardrobe\Core\Repositories;
+
+use Auth, Hash, Validator, Wardrobe, Config;
+use Illuminate\Support\Contracts\MessageProviderInterface;
+
+class FileStorageRepository implements FileStorageRepositoryInterface {
+
+    protected $storageDirectory;
+
+    protected $destinationPath;
+
+    protected $messsages;
+
+    protected $storageDirectories;
+
+    public function __construct(MessageProviderInterface $messages)
+    {
+        $this->messages = $messages;
+        $this->storageDirectories = Config::get('core::wardrobe.storage_directories');
+    }
+
+    /**
+     * Saves file in chosen storge 
+     *
+     * @param  string  $content
+     * @param  string  $last_name
+     * @param  string  $type
+     * 
+     * @return \Illuminate\Support\MessageBag
+     */
+    public function store($content, $filename, $type)
+    {
+        //@note - this is meant to be overridden.
+        return $this->messages->getMessageBag();
+    }
+
+    protected function setDestinationPath($type)
+    {
+        switch($type)
+        {
+            case "image":
+                $this->storageDirectory = $this->storageDirectories['image'];
+                break;
+            default:
+                $this->storageDirectory = $this->storageDirectories['default'];
+                if($dir == "") $this->storageDirectory = "files";
+                break;
+        }
+
+        $this->destinationPath = public_path(). "/{$this->storageDirectory}/";
+    }
+}

--- a/src/Wardrobe/Core/Repositories/FileStorageRepositoryInterface.php
+++ b/src/Wardrobe/Core/Repositories/FileStorageRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php namespace Wardrobe\Core\Repositories;
+
+interface FileStorageRepositoryInterface {
+
+    /**
+     * Saves file in chosen storge 
+     *
+     * @param  string  $content
+     * @param  string  $last_name
+     * @param  string  $type
+     * 
+     * @return \Illuminate\Support\MessageBag
+     */
+    public function store($content, $filename, $type);
+}

--- a/src/Wardrobe/Core/Repositories/LocalFileStorageRepository.php
+++ b/src/Wardrobe/Core/Repositories/LocalFileStorageRepository.php
@@ -1,0 +1,29 @@
+<?php namespace Wardrobe\Core\Repositories;
+
+class LocalFileStorageRepository extends FileStorageRepository {
+
+    /**
+     * Saves file in chosen storge 
+     *
+     * @param  string  $content
+     * @param  string  $last_name
+     * @param  string  $type
+     * 
+     * @return \Illuminate\Support\MessageBag
+     */
+    public function store($content, $filename, $type)
+    {
+        $this->setDestinationPath($type);
+
+        if(file_put_contents($this->destinationPath . $filename, $content) !== false)
+        {
+            $this->messages->add('filename', url($this->storageDirectory."/".$filename));
+        }
+        else
+        {
+            $this->messages->add('error', 'Upload failed. Please ensure the ' . $this->destinationPath . ' directory is writable.');
+        }
+
+        return $this->messages->getMessageBag();
+    }
+}

--- a/src/Wardrobe/Core/Repositories/S3FileStorageRepository.php
+++ b/src/Wardrobe/Core/Repositories/S3FileStorageRepository.php
@@ -1,0 +1,68 @@
+<?php namespace Wardrobe\Core\Repositories;
+
+use Config, File;
+use Illuminate\Support\Contracts\MessageProviderInterface;
+use Aws\S3\S3Client;
+
+class S3FileStorageRepository extends FileStorageRepository {
+
+    /**
+     * AWS S3 Client 
+     *
+     * @var AWS\S3\S3Client
+     */
+    protected $s3Client;
+
+    public function __construct(MessageProviderInterface $messages)
+    {
+        parent::__construct($messages);
+
+        $this->s3Client = S3Client::factory(array(
+            'key'    => Config::get('core::wardrobe.s3_creds.api_key'),
+            'secret' => Config::get('core::wardrobe.s3_creds.api_secret')
+        ));
+    }
+
+    /**
+     * Saves file in chosen storge 
+     *
+     * @param  string  $content
+     * @param  string  $last_name
+     * @param  string  $type
+     * 
+     * @return \Illuminate\Support\MessageBag
+     */
+    public function store($content, $filename, $type)
+    {
+        $this->setDestinationPath($type);
+
+        $file = File::put($this->destinationPath.$filename, $content);
+
+        if(File::exists($this->destinationPath.$filename))
+        {
+            try
+            {
+                $result = $this->s3Client->putObject(array(
+                    'Bucket' => Config::get('core::wardrobe.s3_creds.bucket'),
+                    'Key'    => $this->storageDirectory."/".$filename,
+                    'Body'   => fopen($this->destinationPath.$filename, 'r+'),
+                    'ACL'    => 'public-read'
+                ));
+
+                $this->messages->add('filename', $result['ObjectURL']);
+            }
+            catch(Aws\S3\Exception\S3Exception $e)
+            {
+                $this->messages->add('error', 'Upload failed. Please verify your S3 settings in the config.');
+            }
+
+            File::delete($this->destinationPath.$filename);
+        }
+        else
+        {
+            $this->messages->add('error', 'Upload failed. Please ensure the ' . $this->destinationPath . ' directory is writable.');
+        }
+
+        return $this->messages->getMessageBag();
+    }
+}

--- a/src/Wardrobe/Core/Repositories/S3FileStorageRepository.php
+++ b/src/Wardrobe/Core/Repositories/S3FileStorageRepository.php
@@ -13,6 +13,13 @@ class S3FileStorageRepository extends FileStorageRepository {
      */
     protected $s3Client;
 
+    /**
+     * Constructor
+     *
+     * @param  Illuminate\Support\Contracts\MessageProviderInterface  $messages
+     * 
+     * @return \Wardrobe\Core\Repositories\FileStorageRepositoryInterface
+     */
     public function __construct(MessageProviderInterface $messages)
     {
         parent::__construct($messages);
@@ -24,7 +31,7 @@ class S3FileStorageRepository extends FileStorageRepository {
     }
 
     /**
-     * Saves file in chosen storge 
+     * Saves file in chosen storage 
      *
      * @param  string  $content
      * @param  string  $last_name

--- a/src/Wardrobe/Core/WardrobeServiceProvider.php
+++ b/src/Wardrobe/Core/WardrobeServiceProvider.php
@@ -40,6 +40,19 @@ class WardrobeServiceProvider extends ServiceProvider {
 
 		$this->app->singleton('Wardrobe\Core\Repositories\UserRepositoryInterface', 'Wardrobe\Core\Repositories\DbUserRepository');
 
+		switch(strtolower(Config::get('core::wardrobe.file_storage')))
+		{
+			case "s3":
+				$this->app->bind('Wardrobe\Core\Repositories\FileStorageRepositoryInterface', function () {
+					return new \Wardrobe\Core\Repositories\S3FileStorageRepository(new \Illuminate\Support\MessageBag);
+				});
+				break;
+			default:
+				$this->app->bind('Wardrobe\Core\Repositories\FileStorageRepositoryInterface', function () {
+					return new \Wardrobe\Core\Repositories\LocalFileStorageRepository(new \Illuminate\Support\MessageBag);
+				});
+		}
+
 		$this->app->bind('Wardrobe', function()
 		{
 			return new \Wardrobe\Core\Facades\Wardrobe(new Repositories\DbPostRepository);

--- a/src/config/wardrobe.php
+++ b/src/config/wardrobe.php
@@ -15,14 +15,28 @@ return array(
 
     /*
     |--------------------------------------------------------------------------
-    | Image Uploads Directory
+    | File Storage
     |--------------------------------------------------------------------------
     |
-    | Set this to the directory where your images will be located in your public
+    | Set this to indicate how to store uploaded files. Values are 'filesystem'
+    | or 's3'. If s3 is indicated, set your credentials below.
+    |
+    */
+    'file_storage' => 'filesystem',
+
+    /*
+    |--------------------------------------------------------------------------
+    | File Uploads Directory
+    |--------------------------------------------------------------------------
+    |
+    | Set this to the directory where your files will be located in your public
     | folder.
     |
     */
-    'image_dir' => 'img',
+    'storage_directories' => array(
+        'image'     => 'img',
+        'default'     => 'files',
+    ),
 
     /*
     |--------------------------------------------------------------------------
@@ -37,6 +51,20 @@ return array(
         'enabled'       => false,
         'width'         => '600',
         'height'        => '600',
+    ),
+
+    /*
+    |--------------------------------------------------------------------------
+    | S3 Creds
+    |--------------------------------------------------------------------------
+    |
+    | If using S3 for file storage, specify your S3 credentials here.
+    |
+    */
+    's3_creds' => array(
+        'bucket'       => 'bucket',
+        'api_key'      => 'key',
+        'api_secret'   => 'secret',
     ),
 
     /*
@@ -90,16 +118,16 @@ return array(
     */
     'installed' => true,
 
-	/*
-	|--------------------------------------------------------------------------
-	| Enable Cache
-	|--------------------------------------------------------------------------
-	|
-	| Set this to true to enable caching. If true it will then use the
-	| default laravel cache setup.
-	|
-	*/
-	'cache' => null,
+    /*
+    |--------------------------------------------------------------------------
+    | Enable Cache
+    |--------------------------------------------------------------------------
+    |
+    | Set this to true to enable caching. If true it will then use the
+    | default laravel cache setup.
+    |
+    */
+    'cache' => null,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
As suggested by @ericbarnes, I wrote a file storage interface to allow the ability to store images in other places besides the local system. Currently has drivers for local system and S3. One can easily add more by extending the `FileStorageRepository` class and updating the injections in the `WardrobeServiceProvider`.
