### PR TITLE
make routes and filters boot for sequential tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "laravel/framework": "~4",
     "michelf/php-markdown": "1.3.*@dev",
     "symfony/yaml": "2.4.*@dev",
-    "intervention/image": "1.4.*"
+    "intervention/image": "2.0.*"
   },
   "require-dev": {
     "mockery/mockery": "dev-master",

--- a/src/Wardrobe/Core/Controllers/Api/DropzoneController.php
+++ b/src/Wardrobe/Core/Controllers/Api/DropzoneController.php
@@ -76,7 +76,10 @@ class DropzoneController extends BaseController {
 		{
 			$resizeWidth = Config::get('core::wardrobe.image_resize.width');
 			$resizeHeight = Config::get('core::wardrobe.image_resize.height');
-			$image = Image::make($file->getRealPath())->resize($resizeWidth, $resizeHeight, true);
+			$image = Image::make($file->getRealPath())->resize($resizeWidth, $resizeHeight, function ($constraint) {
+			    $constraint->aspectRatio();
+			});
+
 			$image->save($destinationPath.$filename);
 		}
 		else

--- a/src/Wardrobe/Core/WardrobeServiceProvider.php
+++ b/src/Wardrobe/Core/WardrobeServiceProvider.php
@@ -25,8 +25,8 @@ class WardrobeServiceProvider extends ServiceProvider {
 		$this->bootCommands();
 
 		require_once __DIR__.'/../../themeHelpers.php';
-		require_once __DIR__.'/../../routes.php';
-		require_once __DIR__.'/../../filters.php';
+		require __DIR__.'/../../routes.php';
+		require __DIR__.'/../../filters.php';
 	}
 
 	/**

--- a/src/views/admin/auth/forgot.blade.php
+++ b/src/views/admin/auth/forgot.blade.php
@@ -20,7 +20,7 @@
       </div>
     @endif
 
-    <form method="post" action="/wardrobe/login/remind" class="form-horizontal">
+    <form method="post" action="{{ route('wardrobe.admin.remindForm') }}" class="form-horizontal">
       <p><input type="text" id="inputEmail" name="email" placeholder="{{ Lang::get('core::wardrobe.account_email') }}"></p>
       <button type="submit" class="btn">{{ Lang::get('core::wardrobe.forgot_send') }}</button>
       </div>

--- a/src/views/admin/login.blade.php
+++ b/src/views/admin/login.blade.php
@@ -10,7 +10,7 @@
 		@if (Session::has('login_errors'))
 		<div class="alert alert-block alert-error">
 			<p>
-				{{ Lang::get('core::wardrobe.login_incorrect')}} <a href="{{ url('wardrobe/login/remind') }}">{{ Lang::get('core::wardrobe.login_forgot') }}</a>
+				{{ Lang::get('core::wardrobe.login_incorrect')}} <a href="{{ route('wardrobe.admin.remindForm') }}">{{ Lang::get('core::wardrobe.login_forgot') }}</a>
 			</p>
 		</div>
 		@endif


### PR DESCRIPTION
As mentioned by KuKunin in issue 99 (https://github.com/wardrobecms/core/issues/99) I was having an issue  running sequential tests that indirectly depend on wardrobe routes (i.e. controller / view testing.)

Routes and filters were not being booted after the first test, it appears these changes have solved the issue.

Im not sure that if this creates other implications, but appears to be working.
