### PR TITLE
make routes and filters boot for sequential tests

### DIFF
--- a/src/Wardrobe/Core/WardrobeServiceProvider.php
+++ b/src/Wardrobe/Core/WardrobeServiceProvider.php
@@ -25,8 +25,8 @@ class WardrobeServiceProvider extends ServiceProvider {
 		$this->bootCommands();
 
 		require_once __DIR__.'/../../themeHelpers.php';
-		require_once __DIR__.'/../../routes.php';
-		require_once __DIR__.'/../../filters.php';
+		require __DIR__.'/../../routes.php';
+		require __DIR__.'/../../filters.php';
 	}
 
 	/**


### PR DESCRIPTION
As mentioned by KuKunin in issue 99 (#99) I was having an issue running sequential tests that indirectly depend on wardrobe routes (i.e. controller / view testing.)

Routes and filters were not being booted after the first test, it appears these changes have solved the issue.

Im not sure that if this creates other implications, but appears to be working.
